### PR TITLE
Changed the Namespace to avoid a conflict with the class.

### DIFF
--- a/Source/DMAsteroidScienceGen.cs
+++ b/Source/DMAsteroidScienceGen.cs
@@ -30,7 +30,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
-namespace DMModuleScienceAnimateGeneric
+namespace DMModuleScienceAnimateGeneric_NS
 {
 	public class DMAsteroidScienceGen
 	{

--- a/Source/DMModuleScienceAnimateGeneric.cs
+++ b/Source/DMModuleScienceAnimateGeneric.cs
@@ -35,7 +35,7 @@ using FinePrint.Utilities;
 using KSP.UI.Screens.Flight.Dialogs;
 using Experience.Effects;
 
-namespace DMModuleScienceAnimateGeneric
+namespace DMModuleScienceAnimateGeneric_NS
 {
 	public class DMModuleScienceAnimateGeneric : ModuleScienceExperiment, IScienceDataContainer
 	{

--- a/Source/DMPlanetaryIndicesGen.cs
+++ b/Source/DMPlanetaryIndicesGen.cs
@@ -29,7 +29,7 @@
 
 using System;
 
-namespace DMModuleScienceAnimateGeneric
+namespace DMModuleScienceAnimateGeneric_NS
 {
 	//Enum allows the user to select any combination of planets to allow science on
 	[Flags]

--- a/Source/DMSciAnimAPI.cs
+++ b/Source/DMSciAnimAPI.cs
@@ -31,7 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace DMModuleScienceAnimateGeneric
+namespace DMModuleScienceAnimateGeneric_NS
 {
 	public static class DMSciAnimAPI
 	{


### PR DESCRIPTION
See this page for an explanation:
https://stackoverflow.com/questions/18731415/namespace-and-class-with-the-same-name

I was having weird errors and exceptions as a result of this:
Edit:  As a test to confirm this, I did the following:

1. I downloaded the DMModuleScienceAnimateGeneric
2. changed the namespace ONLY
3. recompiled it
4. put the dll into the game replacing the released version
5. recompiled ScienceAlert using the new dll
6. Removed the DMModuleScienceAnimateGeneric mod
7. and tested, the issues went away.